### PR TITLE
Multi tenancy support

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -7,6 +7,7 @@ module Types
 
     field :groups, [GroupType], null: false do
       description "List all groups"
+      argument :organization_id, ID, required: false
     end
 
     field :post, PostType, null: true do
@@ -23,8 +24,8 @@ module Types
       Group.find_by(slug: slug)
     end
 
-    def groups
-      Group.order(:name)
+    def groups(organization_id: 1)
+      Group.where(organization_id: organization_id).order(:name)
     end
 
     def post(id:)

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,6 +4,7 @@ class Group < ApplicationRecord
 
   has_many :posts
   has_many :bulletins
+  belongs_to :organization
 
   validates :name, presence: true
   validates :slug, uniqueness: { case_sensitive: false },

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,0 +1,6 @@
+class Organization < ApplicationRecord
+  extend FriendlyId
+  friendly_id :name, use: :slugged
+
+  validates :name, presence: true
+end

--- a/db/migrate/20200423213726_create_organizations.rb
+++ b/db/migrate/20200423213726_create_organizations.rb
@@ -1,0 +1,11 @@
+class CreateOrganizations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :organizations do |t|
+      t.string :name, null: false
+      t.string :description
+      t.string :slug, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200423215252_add_organization_id_to_groups.rb
+++ b/db/migrate/20200423215252_add_organization_id_to_groups.rb
@@ -1,0 +1,6 @@
+class AddOrganizationIdToGroups < ActiveRecord::Migration[6.0]
+  def change
+    organization = Organization.create(name: "Montreal Chinese Alliance Church", slug: "mcac")
+    add_reference :groups, :organization, null: false, foreign_key: true, default: organization.id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_23_213726) do
+ActiveRecord::Schema.define(version: 2020_04_23_215252) do
 
   create_table "announcements", force: :cascade do |t|
     t.integer "post_id"
@@ -69,6 +69,8 @@ ActiveRecord::Schema.define(version: 2020_04_23_213726) do
     t.string "short_description"
     t.string "target_audience"
     t.string "meet_details"
+    t.integer "organization_id", default: 1, null: false
+    t.index ["organization_id"], name: "index_groups_on_organization_id"
     t.index ["slug"], name: "index_groups_on_slug", unique: true
   end
 
@@ -155,5 +157,6 @@ ActiveRecord::Schema.define(version: 2020_04_23_213726) do
   end
 
   add_foreign_key "bulletins", "sermons"
+  add_foreign_key "groups", "organizations"
   add_foreign_key "sermons", "groups"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2016_10_11_033416) do
+ActiveRecord::Schema.define(version: 2020_04_23_213726) do
 
   create_table "announcements", force: :cascade do |t|
     t.integer "post_id"
@@ -70,6 +70,14 @@ ActiveRecord::Schema.define(version: 2016_10_11_033416) do
     t.string "target_audience"
     t.string "meet_details"
     t.index ["slug"], name: "index_groups_on_slug", unique: true
+  end
+
+  create_table "organizations", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "description"
+    t.string "slug", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "posts", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,9 @@
+org = FactoryBot.create(
+  :organization,
+  name: "Montreal Chinese Alliance Church",
+  slug: "mcac"
+)
+
 groups = 
   FactoryBot.create_list(:group, 10, :completed) +
   [FactoryBot.create(:group, :completed, name: "English Service", slug: "english-service")]

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     short_description { Faker::Lorem.paragraph }
     meet_details { Faker::Lorem.sentence }
     target_audience { Faker::Lorem.sentence }
+    organization
 
     trait :completed do
       about do

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :organization do
+    sequence(:name) { |n| "Organization #{n}" }
+    description { Faker::Lorem.sentence }
+  end
+end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Organization, type: :model do
+  it "has a valid factory" do
+    expect(build(:organization)).to be_valid
+  end
+
+  context "when creating an organization" do
+    it "will generate a slug" do
+      expect(create(:organization, name: "my organization").slug).
+        to eq "my-organization"
+    end
+
+    it "allows you to customize your slug" do
+      expect(create(:organization, name: "my organization", slug: "my-slug").slug).
+        to eq "my-slug"
+    end
+  end
+end


### PR DESCRIPTION
This PR creates an Organization model that sits atop of Groups.

Groups now belong to an organization in anticipation of supporting multiple organizations.

The `groups` query defaults to organization_id of 1: MCAC.